### PR TITLE
fix(types): ensure typedefs are generated and packed

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist"
   ],
+  "types": "dist/index.d.ts",
   "dependencies": {
     "chokidar": "^2.1.5",
     "debug": "^4.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"baseUrl": "./",
+		"declaration": true,
+		"sourceMap": true,
 		"paths": {
 			"*": [
 				"./src/types/*"


### PR DESCRIPTION
Dunno how we didn't notice this -- no sourcemaps or d.ts files were being generated. And even if they were, we were missing the `types` field in `package.json`.