### PR TITLE
feat(events): emit the value of GameState obj w/ gamestate-changed event

### DIFF
--- a/src/LogWatcher.ts
+++ b/src/LogWatcher.ts
@@ -172,7 +172,7 @@ export class LogWatcher extends HspEventsEmitter {
 		});
 
 		if (updated) {
-			this.emit('gamestate-changed');
+			this.emit('gamestate-changed', gameState);
 		}
 
 		return gameState;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './LogWatcher';
 export {Events} from './line-parsers';
+export {GameState} from './GameState';

--- a/src/line-parsers/index.ts
+++ b/src/line-parsers/index.ts
@@ -5,6 +5,7 @@ import {NewPlayerLineParser} from './new-player';
 import {TurnLineParser} from './turn';
 import {ZoneChangeLineParser} from './zone-change';
 import {TagChangeLineParser} from './tag-change';
+import {GameState} from '../GameState';
 
 export const lineParsers = [
 	new GameOverLineParser(),
@@ -17,7 +18,7 @@ export const lineParsers = [
 ];
 
 export interface Events {
-	'gamestate-changed': void;
+	'gamestate-changed': GameState;
 	'game-over': void;
 	'game-start': void;
 	'mulligan-start': void;

--- a/test/types/tests.ts
+++ b/test/types/tests.ts
@@ -4,7 +4,10 @@ const logWatcher = new LogWatcher();
 logWatcher.start();
 
 // Valid event names.
-logWatcher.on('gamestate-changed', () => {});
+logWatcher.on('gamestate-changed', (gameState) => {
+	gameState.playerCount; // $ExpectType number
+	gameState.gameOverCount; // $ExpectType number
+});
 logWatcher.on('game-over', () => {});
 logWatcher.on('game-start', () => {});
 logWatcher.on('mulligan-start', () => {});
@@ -22,3 +25,9 @@ logWatcher.onAny((event, value) => {
 // Invalid event name.
 // $ExpectError
 logWatcher.on('fakeEvent', () => {});
+
+// Extraneous event args.
+// $ExpectError
+logWatcher.on('game-over', (fakeArg) => {
+	console.log(fakeArg);
+});


### PR DESCRIPTION
This is currently how I plan to get the value of `GameState` from here, through `hearthstone-gamestate-server`, and out to any clients connected via Socket.IO.

Our data delivery pipeline will continue to evolve over time, but this brute-force "idk just send everything any time anything changes" approach gets us up and running quickly.