### PR TITLE
fix(logwatcher): correctly mark gameState arg as optional

### DIFF
--- a/src/LogWatcher.ts
+++ b/src/LogWatcher.ts
@@ -137,11 +137,7 @@ export class LogWatcher extends HspEventsEmitter {
 		this._lastFileSize = 0;
 	}
 
-	parseBuffer(buffer: Buffer, gameState: GameState): GameState {
-		if (!gameState) {
-			gameState = new GameState();
-		}
-
+	parseBuffer(buffer: Buffer, gameState: GameState = new GameState()): GameState {
 		let updated = false;
 
 		// Iterate over each line in the buffer.


### PR DESCRIPTION
The way we were handling this optional argument wasn't quite good enough for TypeScript, which still thought it was mandatory and would not let calling code omit the `gameState` argument.

This change correctly marks this argument as optional, and cleans up the code a little in the process. Nice.

You may be wondering why our Mocha tests weren't failing on this. Turns out that everything added to the test scope is silently given an `any` type, so TypeScript isn't type checking most of our test code. That will need to be fixed separately...