### PR TITLE
feat(typings): export Player interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './LogWatcher';
 export {Events} from './line-parsers';
-export {GameState} from './GameState';
+export {GameState, Player} from './GameState';


### PR DESCRIPTION
I have some code in another project which would like to reference this type directly, but it was unable to do so due to it not being exported. This fixes that.