### PR TITLE
fix: set turn boolean for the first turn

### DIFF
--- a/src/line-parsers/zone-change.ts
+++ b/src/line-parsers/zone-change.ts
@@ -73,8 +73,7 @@ export class ZoneChangeLineParser extends AbstractLineParser {
 		}
 
 		if (gameState.mulliganActive && data.cardName === 'The Coin' && data.toZone === 'HAND') {
-			const position = data.fromTeam === 'FRIENDLY' ? 'top' : 'bottom';
-			const player = gameState.getPlayerByPosition(position);
+			const player = gameState.getPlayerById(3 - data.playerId); // Player 1's opponent is Player 2, Player 2's opponent is Player 1
 			if (player) {
 				player.turn = true;
 			}

--- a/src/line-parsers/zone-change.ts
+++ b/src/line-parsers/zone-change.ts
@@ -71,6 +71,14 @@ export class ZoneChangeLineParser extends AbstractLineParser {
 				player.questCounter = -1;
 			}
 		}
+
+		if (gameState.mulliganActive && data.cardName === 'The Coin' && data.toZone === 'HAND') {
+			const position = data.fromTeam === 'FRIENDLY' ? 'top' : 'bottom';
+			const player = gameState.getPlayerByPosition(position);
+			if (player) {
+				player.turn = true;
+			}
+		}
 	}
 
 	formatLogMessage(parts: string[]): string {


### PR DESCRIPTION
It turns out a turn change event is not emitted on the first turn of a
game. However, we can utilize the presence of the coin in the initial
mulligan to determine who goes first.