### PR TITLE
fix: correct mulligan state for spectated matches

### DIFF
--- a/src/line-parsers/game-tag-change.ts
+++ b/src/line-parsers/game-tag-change.ts
@@ -29,7 +29,7 @@ export class GameTagChangeLineParser extends AbstractLineParser {
 			gameState.turnStartTime = new Date();
 		}
 
-		if (data.entity === 'GameEntity' && data.tag === 'STEP' && data.value === 'BEGIN_MULLIGAN') {
+		if (data.tag === 'MULLIGAN_STATE' && data.value === 'DEALING') {
 			gameState.mulliganActive = true;
 		}
 


### PR DESCRIPTION
Currently it appears that the GameEntity BEGIN_MULLIGAN event is not
being emitted in the Hearthstone log for spectated matches. We should
instead rely on the MULLIGAN_STATE events, which should be outputted
twice for each player per game.