### PR TITLE
fix(game-over): trigger game-over according to animation

### DIFF
--- a/src/line-parsers/game-over.ts
+++ b/src/line-parsers/game-over.ts
@@ -3,7 +3,7 @@ import {GameState} from '../GameState';
 
 // Check if the game is over.
 export class GameOverLineParser extends AbstractLineParser {
-	regex = /\[Power\] GameState\.DebugPrintPower\(\) -\s+TAG_CHANGE Entity=(.*) tag=PLAYSTATE value=(LOST|WON|TIED)/;
+	regex = /\[Power\] PowerTaskList\.DebugPrintPower\(\) -\s+TAG_CHANGE Entity=(.*) tag=PLAYSTATE value=(LOST|WON|TIED)/;
 
 	eventName = 'game-over' as const;
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -96,7 +96,7 @@ describe('hearthstone-log-watcher', () => {
 				'gamestate-changed': 1,
 				'game-over': 2,
 				'game-start': 2,
-				'game-tag-change': 2232,
+				'game-tag-change': 2236,
 				'player-joined': 4,
 				'zone-change': 360,
 				'turn-change': 66,


### PR DESCRIPTION
Long animations like bombs turns `GameState` way too early. This PR uses `PowerTaskList` to sync with animation.