### PR TITLE
fix(game-tag-change): fix regex not capturing non-alphabet battle tag

### DIFF
--- a/src/line-parsers/game-tag-change.ts
+++ b/src/line-parsers/game-tag-change.ts
@@ -17,7 +17,7 @@ function formatParts(parts: string[]): Parts {
 
 // Check for gamestate tag changes.
 export class GameTagChangeLineParser extends AbstractLineParser {
-	regex = /^\[Power\] PowerTaskList.DebugPrintPower\(\) -\s+TAG_CHANGE Entity=([a-zA-Z0-9#]*) tag=(.*) value=(.*)/;
+	regex = /^\[Power\] PowerTaskList.DebugPrintPower\(\) -\s+TAG_CHANGE Entity=(.*) tag=(.*) value=(.*)/;
 
 	eventName = 'game-tag-change' as const;
 


### PR DESCRIPTION
Regex was too strict to capture Chinese/Korean/Japanese etc battle tags.