### PR TITLE
fix: prevent crash with Questing Adventurer

### DIFF
--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -222,9 +222,13 @@ export class GameState {
 	 * @param entity
 	 */
 	resolveEntity(entity: Pick<CardEntity, 'cardName' | 'entityId' | 'cardId'> & Partial<CardEntity>) {
-		this.#entities[entity.entityId] = merge(this.#entities[entity.entityId], entity);
+		const existing = this.#entities[entity.entityId];
+		this.#entities[entity.entityId] = merge({
+			type: 'card',
+			tags: {},
+			player: 'bottom'
+		}, existing, entity);
 
-		// A better algorithm requires caching to a private property
 		const {cardName, entityId, cardId} = entity;
 		const newProps = {entityId, cardName, cardId};
 
@@ -232,6 +236,7 @@ export class GameState {
 			return;
 		}
 
+		// Update entities for each log entry
 		for (const entry of this.matchLog) {
 			if (isEmpty(entry.source.cardName) && entry.source.entityId === entityId) {
 				entry.source = {...entry.source, ...newProps};

--- a/src/line-parsers/block-parser.ts
+++ b/src/line-parsers/block-parser.ts
@@ -17,6 +17,10 @@ class EntityCollection {
 		private readonly gameState: GameState,
 		private readonly entities: {[key: number]: CardEntity}) {}
 
+	values() {
+		return Object.values(this.entities);
+	}
+
 	get(entityId: number) {
 		return this.entities[entityId] ??
 			this.gameState.getEntity(entityId) ??
@@ -148,7 +152,16 @@ export class BlockParser extends LineParser {
 		// Read GameState blocks. These are used to build the Match Log.
 		const block = this.reader.readLine(line, gameState);
 		if (block) {
-			this._handleMatchLog(emitter, gameState, block);
+			try {
+				this._handleMatchLog(emitter, gameState, block);
+			} catch (err) {
+				const source = isCard(block.entity) && block.entity.cardName;
+				const target = isCard(block.target) && block.target.cardName;
+				console.error(`\nFailed to process block: Type=${block.blockType} Source=${source} Target=${target}`);
+				console.trace(err.toString());
+				console.error();
+			}
+
 			return true;
 		}
 
@@ -378,7 +391,7 @@ export class BlockParser extends LineParser {
 		}
 
 		// Merge these entities into the match log (before, for perf)
-		for (const entity of Object.values(entities)) {
+		for (const entity of entities.values()) {
 			gameState.resolveEntity(entity);
 		}
 


### PR DESCRIPTION
The cause was problems with default data in GameState.resolveEntity() , and entities not being added to the global list correctly. Exceptions that happen in match log resolution now show the stack trace in the log and don't stop execution.